### PR TITLE
bug: fix hang when last element in stream takes a long time to process

### DIFF
--- a/src/stringify-stream.js
+++ b/src/stringify-stream.js
@@ -130,7 +130,7 @@ function createStreamReader(fn) {
             current.first = false;
             fn.call(this, data, current);
         } else {
-            if (current.first && !current.value._readableState.reading) {
+            if ((current.first && !current.value._readableState.reading) || current.ended) {
                 this.popStack();
             } else {
                 current.first = true;
@@ -295,6 +295,7 @@ class JsonStringifyStream extends Readable {
                     value,
                     index: 0,
                     first: false,
+                    ended: false,
                     awaiting: !value.readable || value.readableLength === 0
                 });
                 const continueProcessing = () => {
@@ -305,7 +306,10 @@ class JsonStringifyStream extends Readable {
                 };
 
                 value.once('error', error => this.destroy(error));
-                value.once('end', continueProcessing);
+                value.once('end', () => {
+                    self.ended = true;
+                    continueProcessing();
+                });
                 value.on('readable', continueProcessing);
                 break;
         }

--- a/test/stringify-stream.js
+++ b/test/stringify-stream.js
@@ -172,7 +172,8 @@ describe('stringifyStream()', () => {
             [{ a: new StreamClass(1, 2, 3) }, '{"a":[1,2,3]}'],
             [{ a: new StreamClass({ name: 'name', date }) }, `{"a":[{"name":"name","date":"${date.toJSON()}"}]}`],
             [{ a: new StreamClass({ name: 'name', arr: [], obj: {}, date }) }, `{"a":[{"name":"name","arr":[],"obj":{},"date":"${date.toJSON()}"}]}`],
-            [Promise.resolve(new StreamClass(1)), '[1]']
+            [Promise.resolve(new StreamClass(1)), '[1]'],
+            [new StreamClass({ foo: 1 }, { bar: new Promise(resolve => setTimeout(() => resolve(2), 100)) }), '[{"foo":1},{"bar":2}]']
         ];
 
         describe('test cases w/o timeout', () => {


### PR DESCRIPTION
The stream reader assumed there would be a gap between processing the last element in a list & the stream finishing (end event).

This is not always the case - the last element could have an async component or be a very large object which takes a long time to process.

This PR adds an explicit 'ended' flag to the stream node so the parser knows if the stream has actually ended.

Fixes #8