### PR TITLE
restore types package export

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "exports": {
         ".": {
             "require": "./cjs/index.cjs",
-            "import": "./src/index.js"
+            "import": "./src/index.js",
+            "types": "./index.d.ts"
         },
         "./dist/*": "./dist/*",
         "./package.json": "./package.json"


### PR DESCRIPTION
This reverts the recent removal of the `"types"` package export in https://github.com/discoveryjs/json-ext/commit/05c261fe3ed5cf79b31ba65ba72dd234e563645e#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31

Fixes typescript error
> error TS7016: Could not find a declaration file for module '@discoveryjs/json-ext'. '.../node_modules/@discoveryjs/json-ext/src/index.js' implicitly has an 'any' type.
>  There are types at '.../node_modules/@discoveryjs/json-ext/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@discoveryjs/json-ext' library may need to update its package.json or typings.